### PR TITLE
Throw exception when web server fails to start up

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -95,4 +95,16 @@ function wait() {
   setTimeout(wait, 1000);
 }
 
+// Set up a default error handler for any uncaught exceptions. The main one to
+// handle is the obnoxious EADDRINUSE error from ExpressJS.
+process.on("uncaughtException", (err: NodeJS.ErrnoException) => {
+  // EADDRINUSE
+  if (err.errno === -4091) {
+    log.error("Web server", `Another service is already running on port ${process.env.PORT}`);
+  } else {
+    log.error("Main", err.message);
+  }
+  process.exit(1);
+});
+
 main();

--- a/src/webServer.ts
+++ b/src/webServer.ts
@@ -26,7 +26,7 @@ export function start(): void {
       server,
     });
   } catch (e) {
-    log.info("Web server", `Unable to start web server: ${e.error}`);
+    throw new Error(`Unable to start web server: ${e.error}`);
   }
 }
 


### PR DESCRIPTION
Fixes #5

Add an uncaught exception handler. What a royal pain.