### PR TITLE
Support HA addon

### DIFF
--- a/addon/CHANGELOG.md
+++ b/addon/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Version
+
+## 1.0.0
+
+Initial release of HA addon

--- a/addon/Dockerfile
+++ b/addon/Dockerfile
@@ -1,0 +1,1 @@
+FROM ghcr.io/neilenns/ambientweather2mqtt:latest

--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,0 +1,18 @@
+name: AmbientWeather2MQTT
+version: "1.0.0"
+panel_icon: "mdi:cloud"
+panel_title: AmbientWeather2MQTT
+slug: ambientweather2mqtt
+description: This package listens for local data from Ambient Weather stations (such as the WS-2902C) and converts the incoming data to MQTT events.
+url: "https://github.com/neilenns/ambientweather2mqtt"
+startup: application
+boot: auto
+ports:
+  4500/tcp: 8132
+# TODO need to make the options respected as env variables
+options:
+  MAC_ADDRESS: 
+arch:
+  - amd64
+  - armv7
+  - aarch64


### PR DESCRIPTION
Support for #73 

Mostly here, the main problem is getting the docker container to move the config values into env variables so they can be used as they currently are. 

There is an example of that here: https://github.com/jakowenko/double-take/commit/e5adba4147e5e14fb6148d74270e2c55a8db99e4