### PR TITLE
Bug fix - Hourly Rain unit of measurement incorrect

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ The following sensors are supported. Note that weather stations will only report
 | batteryPM25Ok                 | State of the PM25 device battery, `0` for not ok, `100` for ok | Yes             | No                  | percent |
 | co2                           | CO2 meter reading                                              | Yes             | No                  | ppm     |
 | dewpoint                      | Outdoor dewpoint temperature                                   | No              | Yes                 | °F      |
-| eventDate                     | Date of the latest measurements                                | Yes             | Yes                 | date    |     | humidity1..10 | Humidity sensors 1 through 10 | Yes | No  | percent |
+| eventDate                     | Date of the latest measurements                                | Yes             | Yes                 | date    |     
+| humidity1..10 | Humidity sensors 1 through 10 | Yes | No  | percent |
 | humidityIndoor                | Indoor humidity                                                | Yes             | Yes                 | percent |
 | humidityOutdoor               | Outdoor humidity                                               | Yes             | Yes                 | percent |
 | pm25                          | PM2.5 air quality                                              | Yes             | No                  | µg/m^3  |
@@ -112,7 +113,7 @@ The following sensors are supported. Note that weather stations will only report
 | rain24Hour                    | 24 hour rain                                                   | Yes             | No                  | inches  |
 | rainDaily                     | Daily rain                                                     | Yes             | Yes                 | inches  |
 | rainEvent                     | Event rain                                                     | Yes             | No                  | inches  |
-| rainHourly                    | Hourly rain                                                    | Yes             | Yes                 | inches  |
+| rainHourly                    | Hourly rain                                                    | Yes             | Yes                 | in/h    |
 | rainMonthly                   | Monthly rain                                                   | Yes             | Yes                 | inches  |
 | rainTotal                     | Total rain since last factory reset                            | Yes             | No                  | inches  |
 | rainWeekly                    | Weekly rain                                                    | Yes             | Yes                 | inches  |

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The following sensors are supported. Note that weather stations will only report
 | batteryPM25Ok                 | State of the PM25 device battery, `0` for not ok, `100` for ok | Yes             | No                  | percent |
 | co2                           | CO2 meter reading                                              | Yes             | No                  | ppm     |
 | dewpoint                      | Outdoor dewpoint temperature                                   | No              | Yes                 | °F      |
-| eventDate                     | Date of the latest measurements                                | Yes             | Yes                 | date    |     
+| eventDate                     | Date of the latest measurements                                | Yes             | Yes                 | date    |
 | humidity1..10                 | Humidity sensors 1 through 10                                  | Yes             | No                  | percent |
 | humidityIndoor                | Indoor humidity                                                | Yes             | Yes                 | percent |
 | humidityOutdoor               | Outdoor humidity                                               | Yes             | Yes                 | percent |

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The following sensors are supported. Note that weather stations will only report
 | co2                           | CO2 meter reading                                              | Yes             | No                  | ppm     |
 | dewpoint                      | Outdoor dewpoint temperature                                   | No              | Yes                 | °F      |
 | eventDate                     | Date of the latest measurements                                | Yes             | Yes                 | date    |     
-| humidity1..10 | Humidity sensors 1 through 10 | Yes | No  | percent |
+| humidity1..10                 | Humidity sensors 1 through 10                                  | Yes             | No                  | percent |
 | humidityIndoor                | Indoor humidity                                                | Yes             | Yes                 | percent |
 | humidityOutdoor               | Outdoor humidity                                               | Yes             | Yes                 | percent |
 | pm25                          | PM2.5 air quality                                              | Yes             | No                  | µg/m^3  |

--- a/src/entityManager.ts
+++ b/src/entityManager.ts
@@ -164,7 +164,7 @@ export function initialize(): void {
   );
   entities.set(
     EntityNames.RAINHOURLY,
-    new Sensor(EntityNames.RAINHOURLY, deviceId, SensorUnit.inches, undefined, "weather-pouring"),
+    new Sensor(EntityNames.RAINHOURLY, deviceId, SensorUnit.inchesPerHour, undefined, "weather-pouring"),
   );
   entities.set(
     EntityNames.RAINMONTHLY,

--- a/src/sensorUnit.ts
+++ b/src/sensorUnit.ts
@@ -7,6 +7,7 @@ enum SensorUnit {
   F = "˚F",
   illuminance = "lx",
   inches = "in",
+  inchesPerHour = "in/h",
   inHg = "inHg",
   milesPerHour = "mph",
   particulate = "µg/m^3",


### PR DESCRIPTION
Fixes #80 

Hope you don't find this too presumptuous of me. I've been playing with this the past few days since the add-on was created, and noticed a small bug.

`hourlyRain` is being reported as inches, when in fact it should be inches per hour. It is not a static measurement, but a measurement of the current rate of rainfall.

This is confirmed in the documentation [here](https://github.com/ambient-weather/api-docs/wiki/Device-Data-Specs), and also matches what the [official add-on](https://github.com/home-assistant/core/blob/dev/homeassistant/components/ambient_station/sensor.py#L198) reports.