### PR TITLE
Set the device class for EVENTDATE to TIMESTAMP

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "ambientweather2mqtt",
       "version": "4.0.0",
       "license": "MIT",
       "dependencies": {

--- a/src/entityManager.ts
+++ b/src/entityManager.ts
@@ -84,7 +84,7 @@ export function initialize(): void {
   entities.set(EntityNames.DEWPOINT, new Sensor(EntityNames.DEWPOINT, deviceId, SensorUnit.F, DeviceClass.TEMPERATURE));
   entities.set(
     EntityNames.EVENTDATE,
-    new Sensor(EntityNames.EVENTDATE, deviceId, SensorUnit.timestamp, undefined, "clock-outline"),
+    new Sensor(EntityNames.EVENTDATE, deviceId, SensorUnit.timestamp, DeviceClass.TIMESTAMP, "clock-outline"),
   );
   entities.set(
     EntityNames.HUMIDITY1,


### PR DESCRIPTION
Fixes #99 

Honestly I'm not sure if this is going to fix it. Probably not, because there's no guidance from the Home Assistant people on this. Only thing I can see is the `DeviceClass` for this was unknown instead of `TimeStamp` so gonna give that a try.

If it doesn't work then I'll be able to go and open a real issue against the HA team.