### PR TITLE
Set unit of measurement to none

### DIFF
--- a/src/entityManager.ts
+++ b/src/entityManager.ts
@@ -84,7 +84,7 @@ export function initialize(): void {
   entities.set(EntityNames.DEWPOINT, new Sensor(EntityNames.DEWPOINT, deviceId, SensorUnit.F, DeviceClass.TEMPERATURE));
   entities.set(
     EntityNames.EVENTDATE,
-    new Sensor(EntityNames.EVENTDATE, deviceId, SensorUnit.timestamp, DeviceClass.TIMESTAMP, "clock-outline"),
+    new Sensor(EntityNames.EVENTDATE, deviceId, SensorUnit.none, DeviceClass.TIMESTAMP, "clock-outline"),
   );
   entities.set(
     EntityNames.HUMIDITY1,

--- a/src/sensorUnit.ts
+++ b/src/sensorUnit.ts
@@ -15,6 +15,7 @@ enum SensorUnit {
   percent = "%",
   radiation = "W/m^2",
   timestamp = "timestamp",
+  none = "None",
 }
 
 export default SensorUnit;


### PR DESCRIPTION
Fixes #99 (maybe)

Set the sensor unit of measurement for eventdate to `None`.