### PR TITLE
Remove unit of measurement and fix date format for eventDate

### DIFF
--- a/src/controllers/weatherDataController.ts
+++ b/src/controllers/weatherDataController.ts
@@ -117,7 +117,7 @@ export function processWeatherData(req: express.Request, res: express.Response):
   setDataPayload(EntityNames.BATTERYPM25OK, convertBatteryValue(req.query.batt_25 as string));
   setDataPayload(EntityNames.CO2, +req.query.co2);
   setDataPayload(EntityNames.DEWPOINT, +req.query.dewptf); // Only available in Weather Underground updates
-  setDataPayload(EntityNames.EVENTDATE, convertUtcValue(req.query.dateutc?.toString()));
+  setDataPayload(EntityNames.EVENTDATE, convertUtcValue(req.query.dateutc?.toString()).toISOString());
   setDataPayload(EntityNames.HUMIDITY1, +req.query.humidity1);
   setDataPayload(EntityNames.HUMIDITY10, +req.query.humidity10);
   setDataPayload(EntityNames.HUMIDITY2, +req.query.humidity2);

--- a/src/entityDiscoveryPayload.ts
+++ b/src/entityDiscoveryPayload.ts
@@ -18,6 +18,6 @@ export default class EntityDiscoveryPayload {
   command_topic: string;
   state_topic: string;
   unique_id: string;
-  unit_of_measurement: string;
+  unit_of_measurement?: string;
   value_template: string;
 }

--- a/src/entityManager.ts
+++ b/src/entityManager.ts
@@ -84,7 +84,7 @@ export function initialize(): void {
   entities.set(EntityNames.DEWPOINT, new Sensor(EntityNames.DEWPOINT, deviceId, SensorUnit.F, DeviceClass.TEMPERATURE));
   entities.set(
     EntityNames.EVENTDATE,
-    new Sensor(EntityNames.EVENTDATE, deviceId, SensorUnit.none, DeviceClass.TIMESTAMP, "clock-outline"),
+    new Sensor(EntityNames.EVENTDATE, deviceId, undefined, DeviceClass.TIMESTAMP, "clock-outline"),
   );
   entities.set(
     EntityNames.HUMIDITY1,

--- a/src/entityManager.ts
+++ b/src/entityManager.ts
@@ -84,7 +84,7 @@ export function initialize(): void {
   entities.set(EntityNames.DEWPOINT, new Sensor(EntityNames.DEWPOINT, deviceId, SensorUnit.F, DeviceClass.TEMPERATURE));
   entities.set(
     EntityNames.EVENTDATE,
-    new Sensor(EntityNames.EVENTDATE, deviceId, SensorUnit.timestamp, DeviceClass.TIMESTAMP, "clock-outline"),
+    new Sensor(EntityNames.EVENTDATE, deviceId, SensorUnit.none, DeviceClass.TIMESTAMP, "clock-outline"),
   );
   entities.set(
     EntityNames.HUMIDITY1,

--- a/src/sensorUnit.ts
+++ b/src/sensorUnit.ts
@@ -15,6 +15,7 @@ enum SensorUnit {
   percent = "%",
   radiation = "W/m^2",
   timestamp = "timestamp",
+  none = "None",
 }
 
 export default SensorUnit;


### PR DESCRIPTION
Fixes #99 

(FINALLY!!!)

* Remove the unit of measurement from `eventDate`
* Change the format of the string sent for the `eventDate` value to be an ISO formatted string