### PR TITLE
lastRain date not in correct format

### DIFF
--- a/src/controllers/weatherDataController.ts
+++ b/src/controllers/weatherDataController.ts
@@ -237,7 +237,7 @@ export async function processWeatherData(req: express.Request, res: express.Resp
 
   // Calculated sensors
   setDataPayload(EntityNames.SOLARRADIATION_LUX, calculateSolarRadiationLux(+req.query.solarradiation));
-  setDataPayload(EntityNames.LASTRAIN, calculateLastRain(+req.query.hourlyrainin));
+  setDataPayload(EntityNames.LASTRAIN, calculateLastRain(+req.query.hourlyrainin)?.toISOString());
   setDataPayload(
     EntityNames.FEELSLIKE,
     calculateFeelsLike(+req.query.tempf, +req.query.windspeedmph, +req.query.humidity),


### PR DESCRIPTION
Fixes #138

Convert to ISO date format before sending out the lastRain event.

![image](https://github.com/neilenns/ambientweather2mqtt/assets/9524118/31957d59-44a5-4192-8d99-6deb4c4c977d)
