### PR TITLE
Remove calls to bashio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version
 
+## 4.5.1
+
+* Remove bashio calls from HomeAssistant add-on. (Fixes [[#147](https://github.com/neilenns/ambientweather2mqtt/issues/147)])
+
 ## 4.5.0
 
 * Add more logging options to help identify reported issues. (Fixes [#145](https://github.com/neilenns/ambientweather2mqtt/issues/145))

--- a/hassio_aw2m/startup.sh
+++ b/hassio_aw2m/startup.sh
@@ -1,10 +1,4 @@
-#!/usr/bin/env bashio
-# shellcheck shell=bash
-
-# Delete the old VERBOSE option to avoid warnings in the logs
-if bashio::config.exists "VERBOSE"; then
-  bashio::addon.option "VERBOSE"
-fi
+#!/bin/bash
 
 if [ -f "/data/options.json" ]
 then


### PR DESCRIPTION
Fixes #147

They don't work, and Home Assistant doesn't seem to be complaining about the old `VERBOSE` setting not being there anyway.