### PR TITLE
Add Missing AQI Sensors from my WS-5000 Station and a way to set the published Name for the MQTT Name

### DIFF
--- a/src/controllers/weatherDataController.ts
+++ b/src/controllers/weatherDataController.ts
@@ -223,6 +223,8 @@ export async function processWeatherData(req: express.Request, res: express.Resp
   setDataPayload(EntityNames.WINDSPEED, +req.query.windspeedmph);
 
   // AQIN sensors
+  setDataPayload(EntityNames.AQI_PM25_IN, +req.query.aqi_pm25_in);
+  setDataPayload(EntityNames.AQI_PM25_IN_24H, +req.query.aqi_pm25_in_24h);
   setDataPayload(EntityNames.AQI_PM25_24H_AQIN, +req.query.aqi_pm25_24h_aqin);
   setDataPayload(EntityNames.AQI_PM25_AQIN, +req.query.aqi_pm25_aqin);
   setDataPayload(EntityNames.PM25_IN_AQIN, +req.query.pm25_in_aqin);

--- a/src/entityManager.ts
+++ b/src/entityManager.ts
@@ -482,6 +482,14 @@ export function initialize(): void {
 
   // AQIN sensors
   entities.set(
+    EntityNames.AQI_PM25_IN,
+    new Sensor(EntityNames.AQI_PM25_IN, deviceId, SensorUnit.particulate, undefined, "air-filter"),
+  );
+  entities.set(
+    EntityNames.AQI_PM25_IN_24H,
+    new Sensor(EntityNames.AQI_PM25_IN_24H, deviceId, SensorUnit.particulate, undefined, "air-filter"),
+  );
+  entities.set(
     EntityNames.AQI_PM25_AQIN,
     new Sensor(EntityNames.AQI_PM25_AQIN, deviceId, SensorUnit.particulate, undefined, "air-filter"),
   );

--- a/src/entityNames.ts
+++ b/src/entityNames.ts
@@ -107,6 +107,8 @@ enum EntityNames {
   WINDSPEED_AVG10M = "windSpeedTenMinuteAverage",
   WINDSPEED_AVG2M = "windSpeedTwoMinuteAverage",
   // AQIN sensors
+  AQI_PM25_IN = "aqi_pm25_in",
+  AQI_PM25_IN_24H = "aqi_pm25_in_24h",
   AQI_PM25_AQIN = "aqi_pm25_aqin",
   AQI_PM25_24H_AQIN = "aqi_pm25_24h_aqin",
   CO2_IN_AQIN = "co2_in_aqin",


### PR DESCRIPTION
First off thank you for this docker/Addon I have been using it forever. 

I found that my WS-5000 AQI sensors did not get published, found that the query uri is just slightly off from the ones you already had added. This just adds additional ones. 

I also added an environment variable to set the name used for MQTT Device Discovery so that I can have the name show up as my Weather Station instead of "ambientWeather2mqtt" in the MQTT device list (this is just an OCD thing for 😃) 

Example:
![image](https://github.com/neilenns/ambientweather2mqtt/assets/17607285/c05e0dcc-e91f-4dbc-bc99-35c4b06269d7)


As a note, my Main branch has the full changes to also update the Hassio Addon but I did not include those changes here as I had to repoint to my images/repo for testing. figured I would let you do those on your branch if you end up accepting this PR.