### PR TITLE
Add Variable to allow setting a custom Publish Name

### DIFF
--- a/hassio_aw2m/config.yaml
+++ b/hassio_aw2m/config.yaml
@@ -13,6 +13,7 @@ options:
   MQTT_PASSWORD: "password"
   MQTT_REJECT_UNAUTHORIZED: false
   STATION_MAC_ADDRESS: "00:00:00:00:00:00"
+  PUBLISH_NAME: "ambientWeather2mqtt"
   TZ: "America/Los_Angeles"
   LOG_LEVEL: "info"
   RETAIN_SENSOR_VALUES: false
@@ -22,6 +23,7 @@ schema:
   MQTT_PASSWORD: "password"
   MQTT_REJECT_UNAUTHORIZED: "bool"
   STATION_MAC_ADDRESS: "str"
+  PUBLISH_NAME: "str"
   TZ: "str"
   LOG_LEVEL: list(error|warn|info|http|debug)
   RETAIN_SENSOR_VALUES: "bool"

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -48,6 +48,7 @@ export default class Entity {
     icon?: string,
     entityCategory?: EntityCategory,
     retain = false,
+    publishName = env().PUBLISH_NAME,
   ) {
     this.deviceId = deviceId;
     this.retain = retain;
@@ -56,7 +57,7 @@ export default class Entity {
       device: {
         identifiers: [`AW_${this.deviceId}`],
         manufacturer: "Ambient Weather",
-        name: "ambientweather2mqtt",
+        name: publishName,
         model: "Ambient Weather Station",
       },
       device_class: deviceClass,

--- a/src/entityDiscoveryPayload.ts
+++ b/src/entityDiscoveryPayload.ts
@@ -7,7 +7,7 @@ export default class EntityDiscoveryPayload {
   device: {
     identifiers: string[];
     manufacturer: "Ambient Weather";
-    name: "ambientweather2mqtt";
+    name: string;
     model: string;
     sw_version: string;
   };

--- a/src/env.ts
+++ b/src/env.ts
@@ -28,6 +28,7 @@ const envSchema = z.object({
   MQTT_PASSWORD: z.string().optional(),
   MQTT_REJECT_UNAUTHORIZED: z.string().transform<boolean>(booleanTransformer).default("false"),
   STATION_MAC_ADDRESS: z.string(),
+  PUBLISH_NAME: z.string().default("ambientWeather2mqtt"),
   TZ: z.string().default("America/Los_Angeles"),
   TOPIC_ROOT: z.string().optional(),
   NODE_ENV: z.string().default("production"),


### PR DESCRIPTION
Here is the second PR to allow a custom published name in MQTT. I did not add change log data as I figured you would need to do that after the PR is merged and you cut a release. If you want me to include that let me know.